### PR TITLE
updated GxMaskRender.js

### DIFF
--- a/GxMask.control
+++ b/GxMask.control
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ControlDefinition xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <Version>1.0.0</Version>
+  <Version>1.0.2</Version>
   <DataSourceAllowed>None</DataSourceAllowed>
   <CustomDataSources />
   <AutoGrowSupported>false</AutoGrowSupported>

--- a/GxMaskRender.js
+++ b/GxMaskRender.js
@@ -11,27 +11,9 @@ function GxMask($)
 		* e-mail: daniel.smpf@gmail.com
 		* Created at: 05/11/2015
 		*/
-		
-		
 		var control = this.AttachControl;
 		
 		this.addMask(control);
-		jQuery(function($){
-			try {		
-				$('#'+control)[0].onblur = null;
-				$('#'+control).bind('onblur',function(){
-					VMasker(document.querySelector('#'+control)).unMask();
-				});
-			} catch (e) {
-				console.error('Error: adding blur mask.')
-			}
-		});
-		
-		
-		
-		
-		
-		
 		
 		///UserCodeRegionEnd: (do not remove this comment.)
 	}
@@ -39,10 +21,30 @@ function GxMask($)
 
  	this.addMask = function(el)
     {
-		VMasker(document.querySelector('#'+this.AttachControl)).maskPattern(this.Picture);
+		switch(this.Picture){
+			case 'telefone':
+				var telMask = ['(99) 9999-9999', '(99) 99999-9999'];
+				var tel = document.querySelector('#'+this.AttachControl);
+				tel.addEventListener('input', inputHandler.bind(undefined, telMask, 14), false);	
+				break;
+			case 'cpfcnpj':
+				var docMask = ['999.999.999-999', '99.999.999/9999-99'];
+				var doc = document.querySelector('#'+this.AttachControl);
+				doc.addEventListener('input', inputHandler.bind(undefined, docMask, 14), false);
+				break;
+			default:
+				VMasker(document.querySelector('#'+this.AttachControl)).maskPattern(this.Picture);
+		}
 	}
 	
-	
+	function inputHandler(masks, max, event) {
+	  var c = event.target;
+	  var v = c.value.replace(/\D/g, '');
+	  var m = c.value.length > max ? 1 : 0;
+	  VMasker(c).unMask();
+	  VMasker(c).maskPattern(masks[m]);
+	  c.value = VMasker.toPattern(v, masks[m]);
+	}
 	
 	this.removeMask = function(el)
     {


### PR DESCRIPTION
New mask 'telefone' for Brazilian telephones (dynamic, 8 or 9 digits).
New mask 'cpfcnpj' for Brazilian's ID (dynamic).
Update version to 1.0.2